### PR TITLE
Fix fly deploy github action failure

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,6 +11,9 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    env:
+      FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+      FLY_APP_URL: ${{ secrets.FLY_APP_URL }}
     
     steps:
     - name: Checkout code
@@ -27,18 +30,28 @@ jobs:
         pip install -r requirements.txt
         
     - name: Install Flyctl
-      uses: superfly/flyctl-actions/setup-flyctl@master
+      uses: superfly/flyctl-actions/setup-flyctl@v1
       
     - name: Deploy to Fly.io
-      env:
-        FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
       run: |
-        flyctl deploy --remote-only
+        flyctl deploy --app tdg-mvp --remote-only --wait-timeout 300
         
-    - name: Health check
+    - name: Health check (with retries)
       run: |
-        sleep 30
-        curl -f https://tdg-mvp.fly.dev/health || exit 1
+        APP_URL=${FLY_APP_URL:-https://tdg-mvp.fly.dev}
+        echo "Waiting for app to become healthy at $APP_URL/health"
+        for i in {1..30}; do
+          if curl -fsS "$APP_URL/health"; then
+            echo "App is healthy"
+            exit 0
+          fi
+          echo "Attempt $i failed; retrying in 10s..."
+          sleep 10
+        done
+        echo "Health check failed. Showing status and recent logs:"
+        flyctl status --app tdg-mvp | cat
+        flyctl logs --app tdg-mvp --max-lines 100 | cat
+        exit 1
         
     - name: Set up Java
       uses: actions/setup-java@v4

--- a/fly.toml
+++ b/fly.toml
@@ -15,32 +15,19 @@ primary_region = "ord"
   internal_port = 8080
   force_https = true
   auto_stop_machines = true
-  auto_start_machines = false
+  auto_start_machines = true
   min_machines_running = 1
   processes = ["app"]
+
+  [[http_service.checks]]
+    grace_period = "10s"
+    interval = "15s"
+    method = "GET"
+    timeout = "5s"
+    path = "/health"
 
 # Machine configuration for memory management
 [[vm]]
   memory = "1GB"
   cpu_kind = "shared"
   cpus = 1
-
-[[services]]
-  protocol = "tcp"
-  internal_port = 8080
-  
-  [[services.ports]]
-    port = 80
-    handlers = ["http"]
-    
-  [[services.ports]]
-    port = 443
-    handlers = ["tls", "http"]
-
-[checks]
-  [checks.health]
-    port = 8080
-    type = "http"
-    interval = "15s"
-    timeout = "5s"
-    path = "/health"


### PR DESCRIPTION
Update Fly.io configuration and GitHub Actions workflow to fix deploy failures caused by conflicting config and a brittle health check.

The `fly.toml` had a mix of legacy `[[services]]` and `[checks]` with the newer `http_service` (Machines platform), which often leads to deployment rejections or unexpected behavior on Fly.io. Additionally, the previous fixed-timeout health check in the GitHub Action was prone to false failures during cold starts, which is now replaced with a robust retrying check that provides better debugging information.

---
<a href="https://cursor.com/background-agent?bcId=bc-d4b28423-e34e-40ad-a9fe-8cd93772f07a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d4b28423-e34e-40ad-a9fe-8cd93772f07a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

